### PR TITLE
Add Open VSX publishing support

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -25,3 +25,10 @@ jobs:
         pat: ${{ secrets.VSCE_PAT }}
         registryUrl: https://marketplace.visualstudio.com
         packagePath: ./dist/vscode
+
+    - name: Publish to Open VSX
+      uses: HaaLeo/publish-vscode-extension@v2
+      with:
+        pat: ${{ secrets.OVSX_PAT }}
+        registryUrl: https://open-vsx.org
+        packagePath: ./dist/vscode

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ warm, and readable for long sessions.
 | [Alacritty](dist/alacritty/README.md) | Terminal Emulator | Import theme in `alacritty.toml` |
 | [Helix](dist/helix/README.md) | Editor | Copy theme to `~/.config/helix/themes/` |
 | [Neovim](dist/nvim/README.md) | Editor | Install via plugin manager |
-| [Visual Studio Code](dist/vscode/README.md) | Editor | Install from [Marketplace](https://marketplace.visualstudio.com/items?itemName=cappyzawa.akari-theme) |
+| [Visual Studio Code](dist/vscode/README.md) | Editor | Install from [Marketplace](https://marketplace.visualstudio.com/items?itemName=cappyzawa.akari-theme) or [Open VSX](https://open-vsx.org/extension/cappyzawa/akari-theme) |
 | [Starship](dist/starship/README.md) | Prompt | Add palette to `~/.config/starship.toml` |
 | [tmux](dist/tmux/README.md) | Terminal Multiplexer | Source config in `.tmux.conf` |
 | [macOS Terminal](dist/terminal/README.md) | Terminal Emulator | Double-click to import profile |

--- a/dist/vscode/README.md
+++ b/dist/vscode/README.md
@@ -34,6 +34,16 @@ it is about warm light, quiet streets, and the presence of life.
 5. Select **Preferences: Color Theme**
 6. Choose **Akari Night** or **Akari Dawn**
 
+### From Open VSX (for Cursor, VSCodium, etc.)
+
+1. Open **Extensions** sidebar
+2. Search for `Akari`
+3. Click **Install**
+4. Select **Preferences: Color Theme**
+5. Choose **Akari Night** or **Akari Dawn**
+
+Or install directly from [Open VSX](https://open-vsx.org/extension/cappyzawa/akari-theme).
+
 ### From this repository
 
 Clone and symlink to your VS Code extensions directory:

--- a/templates/vscode/README.md
+++ b/templates/vscode/README.md
@@ -34,6 +34,16 @@ it is about warm light, quiet streets, and the presence of life.
 5. Select **Preferences: Color Theme**
 6. Choose **Akari Night** or **Akari Dawn**
 
+### From Open VSX (for Cursor, VSCodium, etc.)
+
+1. Open **Extensions** sidebar
+2. Search for `Akari`
+3. Click **Install**
+4. Select **Preferences: Color Theme**
+5. Choose **Akari Night** or **Akari Dawn**
+
+Or install directly from [Open VSX](https://open-vsx.org/extension/cappyzawa/akari-theme).
+
 ### From this repository
 
 Clone and symlink to your VS Code extensions directory:


### PR DESCRIPTION
## Summary

- Add Open VSX Registry publishing to VSCode workflow
- Update documentation with Open VSX installation instructions

This enables users of Cursor, VSCodium, and other VS Code-compatible editors to install the theme from Open VSX.