### PR TITLE
Add semantic.path for consistent path coloring

### DIFF
--- a/dist/helix/akari-dawn.toml
+++ b/dist/helix/akari-dawn.toml
@@ -124,7 +124,7 @@
 "string.regexp" = { fg = "bright-green" }
 "string.regexp.special" = { fg = "bright-magenta" }
 "string.special" = { fg = "green" }
-"string.special.path" = { fg = "bright-green" }
+"string.special.path" = { fg = "path" }
 "string.special.url" = { fg = "bright-blue", modifiers = ["underlined"] }
 "string.special.symbol" = { fg = "bright-magenta" }
 
@@ -215,5 +215,6 @@ ember = "#7A3828"
 amber = "#B07840"
 constant = "#406868"
 comment = "#4A4642"
+path = "#70A868"
 sunken = "#DCD4CA"
 match-bg = "#D8C8B8"

--- a/dist/helix/akari-night.toml
+++ b/dist/helix/akari-night.toml
@@ -124,7 +124,7 @@
 "string.regexp" = { fg = "bright-green" }
 "string.regexp.special" = { fg = "bright-magenta" }
 "string.special" = { fg = "green" }
-"string.special.path" = { fg = "bright-green" }
+"string.special.path" = { fg = "path" }
 "string.special.url" = { fg = "bright-blue", modifiers = ["underlined"] }
 "string.special.symbol" = { fg = "bright-magenta" }
 
@@ -215,5 +215,6 @@ ember = "#D65A3A"
 amber = "#D4A05A"
 constant = "#8FB8B0"
 comment = "#7D8797"
+path = "#8FC57A"
 sunken = "#302121"
 match-bg = "#3A2522"

--- a/dist/nvim/lua/akari/highlights/treesitter.lua
+++ b/dist/nvim/lua/akari/highlights/treesitter.lua
@@ -30,7 +30,7 @@ function M.setup(p, config)
     ["@string.escape"] = { fg = p.bright_magenta },
     ["@string.special"] = { fg = p.green },
     ["@string.special.symbol"] = { fg = p.bright_magenta },
-    ["@string.special.path"] = { fg = p.bright_green },
+    ["@string.special.path"] = { fg = p.path },
     ["@string.special.url"] = { fg = p.bright_blue, underline = true },
 
     -- Characters

--- a/dist/nvim/lua/akari/palette.lua
+++ b/dist/nvim/lua/akari/palette.lua
@@ -48,6 +48,7 @@ M.night = {
   amber = "#D4A05A",
   constant = "#8FB8B0",
   comment = "#7D8797",
+  path = "#8FC57A",
 
   -- Diagnostic
   error = "#C84C32",
@@ -109,6 +110,7 @@ M.dawn = {
   amber = "#B07840",
   constant = "#406868",
   comment = "#4A4642",
+  path = "#70A868",
 
   -- Diagnostic
   error = "#B04030",

--- a/dist/zsh/akari-dawn.zsh
+++ b/dist/zsh/akari-dawn.zsh
@@ -13,6 +13,7 @@ _night='#304050'
 _muted='#806080'
 _cyan='#305858'
 _constant='#406868'
+_path='#70A868'
 _text='#1A1816'
 _comment='#4A4642'
 _border='#C4BEB6'
@@ -28,8 +29,8 @@ ZSH_HIGHLIGHT_STYLES[unknown-token]="fg=$_comment"
 ZSH_HIGHLIGHT_STYLES[reserved-word]="fg=$_night"
 
 # Paths and files
-ZSH_HIGHLIGHT_STYLES[path]="fg=$_amber,underline"
-ZSH_HIGHLIGHT_STYLES[path_pathseparator]="fg=$_amber"
+ZSH_HIGHLIGHT_STYLES[path]="fg=$_path,underline"
+ZSH_HIGHLIGHT_STYLES[path_pathseparator]="fg=$_path"
 ZSH_HIGHLIGHT_STYLES[globbing]="fg=$_comment"
 
 # Strings and quotes
@@ -62,4 +63,4 @@ ZSH_HIGHLIGHT_STYLES[default]="fg=$_text"
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=$_comment"
 
 # Cleanup temporary variables
-unset _lantern _ember _amber _life _night _muted _cyan _constant _text _comment _border
+unset _lantern _ember _amber _life _night _muted _cyan _constant _path _text _comment _border

--- a/dist/zsh/akari-night.zsh
+++ b/dist/zsh/akari-night.zsh
@@ -13,6 +13,7 @@ _night='#5A6F82'
 _muted='#7C6A8A'
 _cyan='#6F8F8A'
 _constant='#8FB8B0'
+_path='#8FC57A'
 _text='#E6DED3'
 _comment='#7D8797'
 _border='#262F3B'
@@ -28,8 +29,8 @@ ZSH_HIGHLIGHT_STYLES[unknown-token]="fg=$_comment"
 ZSH_HIGHLIGHT_STYLES[reserved-word]="fg=$_night"
 
 # Paths and files
-ZSH_HIGHLIGHT_STYLES[path]="fg=$_amber,underline"
-ZSH_HIGHLIGHT_STYLES[path_pathseparator]="fg=$_amber"
+ZSH_HIGHLIGHT_STYLES[path]="fg=$_path,underline"
+ZSH_HIGHLIGHT_STYLES[path_pathseparator]="fg=$_path"
 ZSH_HIGHLIGHT_STYLES[globbing]="fg=$_comment"
 
 # Strings and quotes
@@ -62,4 +63,4 @@ ZSH_HIGHLIGHT_STYLES[default]="fg=$_text"
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=$_comment"
 
 # Cleanup temporary variables
-unset _lantern _ember _amber _life _night _muted _cyan _constant _text _comment _border
+unset _lantern _ember _amber _life _night _muted _cyan _constant _path _text _comment _border

--- a/palette/akari-dawn.toml
+++ b/palette/akari-dawn.toml
@@ -119,6 +119,10 @@ variable = "base.foreground"
 # semantic.success
 success = "colors.life"
 
+# Path
+# semantic.path — file paths (URLs use bright-blue separately)
+path = "ansi_bright.green"
+
 #
 # ANSI (terminal compatibility)
 #

--- a/palette/akari-night.toml
+++ b/palette/akari-night.toml
@@ -119,6 +119,10 @@ variable = "base.foreground"
 # semantic.success
 success = "colors.life"
 
+# Path
+# semantic.path — file paths (URLs use bright-blue separately)
+path = "ansi_bright.green"
+
 #
 # ANSI (terminal compatibility)
 #

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -97,6 +97,7 @@ struct RawSemantic {
     function: String,
     variable: String,
     success: String,
+    path: String,
 }
 
 // Resolved types (after reference resolution)
@@ -210,6 +211,7 @@ pub struct Semantic {
     pub function: String,
     pub variable: String,
     pub success: String,
+    pub path: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -245,6 +247,7 @@ struct Resolver<'a> {
     base: BTreeMap<&'a str, &'a str>,
     layers: BTreeMap<&'a str, &'a str>,
     state: BTreeMap<&'a str, &'a str>,
+    ansi_bright: BTreeMap<&'a str, &'a str>,
 }
 
 impl<'a> Resolver<'a> {
@@ -293,6 +296,18 @@ impl<'a> Resolver<'a> {
             ]
             .into_iter()
             .collect(),
+            ansi_bright: [
+                ("black", raw.ansi.bright.black.as_str()),
+                ("red", raw.ansi.bright.red.as_str()),
+                ("green", raw.ansi.bright.green.as_str()),
+                ("yellow", raw.ansi.bright.yellow.as_str()),
+                ("blue", raw.ansi.bright.blue.as_str()),
+                ("magenta", raw.ansi.bright.magenta.as_str()),
+                ("cyan", raw.ansi.bright.cyan.as_str()),
+                ("white", raw.ansi.bright.white.as_str()),
+            ]
+            .into_iter()
+            .collect(),
         }
     }
 
@@ -308,6 +323,7 @@ impl<'a> Resolver<'a> {
             "base" => &self.base,
             "layers" => &self.layers,
             "state" => &self.state,
+            "ansi_bright" => &self.ansi_bright,
             _ => return Err(Error::UnresolvedRef(value.to_string())),
         };
         map.get(key)
@@ -347,6 +363,7 @@ impl Palette {
             function: resolver.resolve(&raw.semantic.function)?,
             variable: resolver.resolve(&raw.semantic.variable)?,
             success: resolver.resolve(&raw.semantic.success)?,
+            path: resolver.resolve(&raw.semantic.path)?,
         };
 
         let ansi = Ansi {
@@ -574,6 +591,7 @@ type = "colors.amber"
 function = "colors.lantern"
 variable = "base.foreground"
 success = "colors.life"
+path = "ansi_bright.green"
 
 [ansi]
 black = "#171B22"

--- a/templates/helix/akari-{name}.toml.tera
+++ b/templates/helix/akari-{name}.toml.tera
@@ -124,7 +124,7 @@
 "string.regexp" = { fg = "bright-green" }
 "string.regexp.special" = { fg = "bright-magenta" }
 "string.special" = { fg = "green" }
-"string.special.path" = { fg = "bright-green" }
+"string.special.path" = { fg = "path" }
 "string.special.url" = { fg = "bright-blue", modifiers = ["underlined"] }
 "string.special.symbol" = { fg = "bright-magenta" }
 
@@ -215,5 +215,6 @@ ember = "{{ colors.ember }}"
 amber = "{{ colors.amber }}"
 constant = "{{ semantic.constant }}"
 comment = "{{ semantic.comment }}"
+path = "{{ semantic.path }}"
 sunken = "{{ layers.sunken }}"
 match-bg = "{{ state.match_bg }}"

--- a/templates/nvim/lua/akari/highlights/treesitter.lua
+++ b/templates/nvim/lua/akari/highlights/treesitter.lua
@@ -30,7 +30,7 @@ function M.setup(p, config)
     ["@string.escape"] = { fg = p.bright_magenta },
     ["@string.special"] = { fg = p.green },
     ["@string.special.symbol"] = { fg = p.bright_magenta },
-    ["@string.special.path"] = { fg = p.bright_green },
+    ["@string.special.path"] = { fg = p.path },
     ["@string.special.url"] = { fg = p.bright_blue, underline = true },
 
     -- Characters

--- a/templates/nvim/lua/akari/palette.lua.tera
+++ b/templates/nvim/lua/akari/palette.lua.tera
@@ -48,6 +48,7 @@ M.night = {
   amber = "{{ night_colors.amber }}",
   constant = "{{ night_semantic.constant }}",
   comment = "{{ night_semantic.comment }}",
+  path = "{{ night_semantic.path }}",
 
   -- Diagnostic
   error = "{{ night_state.error }}",
@@ -109,6 +110,7 @@ M.dawn = {
   amber = "{{ dawn_colors.amber }}",
   constant = "{{ dawn_semantic.constant }}",
   comment = "{{ dawn_semantic.comment }}",
+  path = "{{ dawn_semantic.path }}",
 
   -- Diagnostic
   error = "{{ dawn_state.error }}",

--- a/templates/zsh/akari-{name}.zsh.tera
+++ b/templates/zsh/akari-{name}.zsh.tera
@@ -13,6 +13,7 @@ _night='{{ colors.night }}'
 _muted='{{ colors.muted }}'
 _cyan='{{ ansi.cyan }}'
 _constant='{{ semantic.constant }}'
+_path='{{ semantic.path }}'
 _text='{{ base.foreground }}'
 _comment='{{ semantic.comment }}'
 _border='{{ layers.border }}'
@@ -28,8 +29,8 @@ ZSH_HIGHLIGHT_STYLES[unknown-token]="fg=$_comment"
 ZSH_HIGHLIGHT_STYLES[reserved-word]="fg=$_night"
 
 # Paths and files
-ZSH_HIGHLIGHT_STYLES[path]="fg=$_amber,underline"
-ZSH_HIGHLIGHT_STYLES[path_pathseparator]="fg=$_amber"
+ZSH_HIGHLIGHT_STYLES[path]="fg=$_path,underline"
+ZSH_HIGHLIGHT_STYLES[path_pathseparator]="fg=$_path"
 ZSH_HIGHLIGHT_STYLES[globbing]="fg=$_comment"
 
 # Strings and quotes
@@ -62,4 +63,4 @@ ZSH_HIGHLIGHT_STYLES[default]="fg=$_text"
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=$_comment"
 
 # Cleanup temporary variables
-unset _lantern _ember _amber _life _night _muted _cyan _constant _text _comment _border
+unset _lantern _ember _amber _life _night _muted _cyan _constant _path _text _comment _border


### PR DESCRIPTION
## Summary
- Add `semantic.path` to night/dawn palettes, referencing `ansi_bright.green`
- Update Resolver to support `ansi_bright` references
- Unify path coloring across helix, zsh, and nvim (previously zsh used amber while others used bright-green)

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [x] `cargo run -- generate --tool all` regenerates all themes correctly