### PR TITLE
Use selection-fg for selected item foreground in light theme

### DIFF
--- a/dist/fzf/akari-dawn.sh
+++ b/dist/fzf/akari-dawn.sh
@@ -1,7 +1,7 @@
 # Akari Dawn — fzf theme
 export FZF_DEFAULT_OPTS="
 	--color=fg:#1A1816,bg:#E4DED6,hl:#8A4530
-	--color=fg+:#D0C5B7,bg+:#D7C5B1,hl+:#8A4530
+	--color=fg+:#1A1816,bg+:#D7C5B1,hl+:#8A4530
 	--color=border:#CABEAE,header:#222D38,gutter:#E4DED6
 	--color=spinner:#8A4530,info:#304050
 	--color=pointer:#8A4530,marker:#3A5830,prompt:#8A4530"

--- a/dist/fzf/akari-night.sh
+++ b/dist/fzf/akari-night.sh
@@ -1,7 +1,7 @@
 # Akari Night — fzf theme
 export FZF_DEFAULT_OPTS="
 	--color=fg:#E6DED3,bg:#10141C,hl:#E26A3B
-	--color=fg+:#EFEAE3,bg+:#2D2925,hl+:#E26A3B
+	--color=fg+:#E6DED3,bg+:#2D2925,hl+:#E26A3B
 	--color=border:#262F3B,header:#7E93A6,gutter:#10141C
 	--color=spinner:#E26A3B,info:#5A6F82
 	--color=pointer:#E26A3B,marker:#7FAF6A,prompt:#E26A3B"

--- a/dist/helix/akari-dawn.toml
+++ b/dist/helix/akari-dawn.toml
@@ -3,7 +3,7 @@
 # UI elements
 "ui.background" = { bg = "background" }
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "bright-white" }
+"ui.text.focus" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.text.inactive" = { fg = "bright-black" }
 
 "ui.cursor" = { fg = "cursor-text", bg = "cursor" }
@@ -33,7 +33,7 @@
 "ui.help" = { fg = "foreground", bg = "raised" }
 
 "ui.menu" = { fg = "foreground", bg = "raised" }
-"ui.menu.selected" = { fg = "bright-white", bg = "selection-bg" }
+"ui.menu.selected" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.menu.scroll" = { fg = "bright-black", bg = "raised" }
 
 "ui.virtual.ruler" = { bg = "surface" }

--- a/dist/helix/akari-night.toml
+++ b/dist/helix/akari-night.toml
@@ -3,7 +3,7 @@
 # UI elements
 "ui.background" = { bg = "background" }
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "bright-white" }
+"ui.text.focus" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.text.inactive" = { fg = "bright-black" }
 
 "ui.cursor" = { fg = "cursor-text", bg = "cursor" }
@@ -33,7 +33,7 @@
 "ui.help" = { fg = "foreground", bg = "raised" }
 
 "ui.menu" = { fg = "foreground", bg = "raised" }
-"ui.menu.selected" = { fg = "bright-white", bg = "selection-bg" }
+"ui.menu.selected" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.menu.scroll" = { fg = "bright-black", bg = "raised" }
 
 "ui.virtual.ruler" = { bg = "surface" }

--- a/dist/nvim/lua/akari/highlights/editor.lua
+++ b/dist/nvim/lua/akari/highlights/editor.lua
@@ -60,7 +60,7 @@ function M.setup(p, config)
 
     -- Popup menu
     Pmenu = { fg = p.foreground, bg = p.black },
-    PmenuSel = { fg = p.bright_white, bg = p.selection_bg },
+    PmenuSel = { fg = p.selection_fg, bg = p.selection_bg },
     PmenuSbar = { bg = p.black },
     PmenuThumb = { bg = p.bright_black },
     PmenuKind = { fg = p.lantern, bg = p.black },
@@ -109,7 +109,7 @@ function M.setup(p, config)
     SpecialKey = { fg = p.bright_black },
     Title = { fg = p.lantern, bold = true },
     Whitespace = { fg = p.bright_black },
-    WildMenu = { fg = p.bright_white, bg = p.selection_bg },
+    WildMenu = { fg = p.selection_fg, bg = p.selection_bg },
 
     -- Diagnostics
     DiagnosticError = { fg = p.error, bold = true },

--- a/templates/fzf/akari-{name}.sh.tera
+++ b/templates/fzf/akari-{name}.sh.tera
@@ -1,7 +1,7 @@
 # Akari {{ variant | title }} — fzf theme
 export FZF_DEFAULT_OPTS="
 	--color=fg:{{ base.foreground }},bg:{{ base.background }},hl:{{ colors.lantern.mid }}
-	--color=fg+:{{ ansi_bright.white }},bg+:{{ state.selection_bg }},hl+:{{ colors.lantern.mid }}
+	--color=fg+:{{ state.selection_fg }},bg+:{{ state.selection_bg }},hl+:{{ colors.lantern.mid }}
 	--color=border:{{ layers.border }},header:{{ semantic.comment }},gutter:{{ base.background }}
 	--color=spinner:{{ colors.lantern.mid }},info:{{ colors.night }}
 	--color=pointer:{{ colors.lantern.mid }},marker:{{ colors.life }},prompt:{{ colors.lantern.mid }}"

--- a/templates/helix/akari-{name}.toml.tera
+++ b/templates/helix/akari-{name}.toml.tera
@@ -3,7 +3,7 @@
 # UI elements
 "ui.background" = { bg = "background" }
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "bright-white" }
+"ui.text.focus" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.text.inactive" = { fg = "bright-black" }
 
 "ui.cursor" = { fg = "cursor-text", bg = "cursor" }
@@ -33,7 +33,7 @@
 "ui.help" = { fg = "foreground", bg = "raised" }
 
 "ui.menu" = { fg = "foreground", bg = "raised" }
-"ui.menu.selected" = { fg = "bright-white", bg = "selection-bg" }
+"ui.menu.selected" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.menu.scroll" = { fg = "bright-black", bg = "raised" }
 
 "ui.virtual.ruler" = { bg = "surface" }

--- a/templates/nvim/lua/akari/highlights/editor.lua
+++ b/templates/nvim/lua/akari/highlights/editor.lua
@@ -60,7 +60,7 @@ function M.setup(p, config)
 
     -- Popup menu
     Pmenu = { fg = p.foreground, bg = p.black },
-    PmenuSel = { fg = p.bright_white, bg = p.selection_bg },
+    PmenuSel = { fg = p.selection_fg, bg = p.selection_bg },
     PmenuSbar = { bg = p.black },
     PmenuThumb = { bg = p.bright_black },
     PmenuKind = { fg = p.lantern, bg = p.black },
@@ -109,7 +109,7 @@ function M.setup(p, config)
     SpecialKey = { fg = p.bright_black },
     Title = { fg = p.lantern, bold = true },
     Whitespace = { fg = p.bright_black },
-    WildMenu = { fg = p.bright_white, bg = p.selection_bg },
+    WildMenu = { fg = p.selection_fg, bg = p.selection_bg },
 
     -- Diagnostics
     DiagnosticError = { fg = p.error, bold = true },


### PR DESCRIPTION
## Summary
- Fix poor contrast for selected items in Dawn (light) theme
- `bright-white` was too similar to selection background, making text hard to read

## Changes
- **helix**: `ui.text.focus`, `ui.menu.selected`
- **fzf**: `fg+` (selected line foreground)
- **nvim**: `PmenuSel`, `WildMenu`

## Test plan
- [x] Verify selection visibility in Helix with Dawn theme
- [x] Verify fzf selection visibility with Dawn theme
- [ ] Verify nvim popup menu visibility with Dawn theme