### PR TITLE
Add semantic keys for special syntax highlighting

### DIFF
--- a/dist/helix/akari-dawn.toml
+++ b/dist/helix/akari-dawn.toml
@@ -95,7 +95,7 @@
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "bright-blue", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "link", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "cyan" }
 "markup.link.label" = { fg = "magenta" }
 "markup.quote" = { fg = "comment", modifiers = ["dim"] }
@@ -117,15 +117,15 @@
 "constant.builtin" = { fg = "constant" }
 "constant.builtin.boolean" = { fg = "constant" }
 "constant.character" = { fg = "lantern" }
-"constant.character.escape" = { fg = "bright-magenta" }
+"constant.character.escape" = { fg = "escape" }
 "constant.numeric" = { fg = "constant" }
 
 "string" = { fg = "green" }
-"string.regexp" = { fg = "bright-green" }
+"string.regexp" = { fg = "regexp" }
 "string.regexp.special" = { fg = "bright-magenta" }
 "string.special" = { fg = "green" }
 "string.special.path" = { fg = "path" }
-"string.special.url" = { fg = "bright-blue", modifiers = ["underlined"] }
+"string.special.url" = { fg = "link", modifiers = ["underlined"] }
 "string.special.symbol" = { fg = "bright-magenta" }
 
 "comment" = { fg = "comment", modifiers = ["dim"] }
@@ -154,7 +154,7 @@
 "keyword.control.return" = { fg = "lantern" }
 "keyword.control.exception" = { fg = "lantern" }
 "keyword.operator" = { fg = "lantern" }
-"keyword.directive" = { fg = "bright-magenta" }
+"keyword.directive" = { fg = "macro" }
 "keyword.function" = { fg = "lantern" }
 "keyword.storage" = { fg = "lantern" }
 "keyword.storage.type" = { fg = "lantern" }
@@ -165,7 +165,7 @@
 "function" = { fg = "magenta" }
 "function.builtin" = { fg = "bright-magenta" }
 "function.method" = { fg = "magenta" }
-"function.macro" = { fg = "bright-magenta" }
+"function.macro" = { fg = "macro" }
 "function.special" = { fg = "bright-magenta" }
 
 "tag" = { fg = "lantern" }
@@ -216,5 +216,9 @@ amber = "#B07840"
 constant = "#447C7C"
 comment = "#222D38"
 path = "#3A5830"
+macro = "#543F54"
+escape = "#543F54"
+regexp = "#20301A"
+link = "#131A20"
 sunken = "#DDD2C9"
 match-bg = "#D2BFB5"

--- a/dist/helix/akari-night.toml
+++ b/dist/helix/akari-night.toml
@@ -95,7 +95,7 @@
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "bright-blue", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "link", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "cyan" }
 "markup.link.label" = { fg = "magenta" }
 "markup.quote" = { fg = "comment", modifiers = ["dim"] }
@@ -117,15 +117,15 @@
 "constant.builtin" = { fg = "constant" }
 "constant.builtin.boolean" = { fg = "constant" }
 "constant.character" = { fg = "lantern" }
-"constant.character.escape" = { fg = "bright-magenta" }
+"constant.character.escape" = { fg = "escape" }
 "constant.numeric" = { fg = "constant" }
 
 "string" = { fg = "green" }
-"string.regexp" = { fg = "bright-green" }
+"string.regexp" = { fg = "regexp" }
 "string.regexp.special" = { fg = "bright-magenta" }
 "string.special" = { fg = "green" }
 "string.special.path" = { fg = "path" }
-"string.special.url" = { fg = "bright-blue", modifiers = ["underlined"] }
+"string.special.url" = { fg = "link", modifiers = ["underlined"] }
 "string.special.symbol" = { fg = "bright-magenta" }
 
 "comment" = { fg = "comment", modifiers = ["dim"] }
@@ -154,7 +154,7 @@
 "keyword.control.return" = { fg = "lantern" }
 "keyword.control.exception" = { fg = "lantern" }
 "keyword.operator" = { fg = "lantern" }
-"keyword.directive" = { fg = "bright-magenta" }
+"keyword.directive" = { fg = "macro" }
 "keyword.function" = { fg = "lantern" }
 "keyword.storage" = { fg = "lantern" }
 "keyword.storage.type" = { fg = "lantern" }
@@ -165,7 +165,7 @@
 "function" = { fg = "magenta" }
 "function.builtin" = { fg = "bright-magenta" }
 "function.method" = { fg = "magenta" }
-"function.macro" = { fg = "bright-magenta" }
+"function.macro" = { fg = "macro" }
 "function.special" = { fg = "bright-magenta" }
 
 "tag" = { fg = "lantern" }
@@ -216,5 +216,9 @@ amber = "#D4A05A"
 constant = "#8CA6A1"
 comment = "#7E93A6"
 path = "#7FAF6A"
+macro = "#A294AD"
+escape = "#A294AD"
+regexp = "#A1C492"
+link = "#8195A8"
 sunken = "#302121"
 match-bg = "#3A2522"

--- a/dist/nvim/lua/akari/palette.lua
+++ b/dist/nvim/lua/akari/palette.lua
@@ -49,6 +49,10 @@ M.night = {
   constant = "#8CA6A1",
   comment = "#7E93A6",
   path = "#7FAF6A",
+  macro = "#A294AD",
+  escape = "#A294AD",
+  regexp = "#A1C492",
+  link = "#8195A8",
 
   -- Diagnostic
   error = "#D25046",
@@ -111,6 +115,10 @@ M.dawn = {
   constant = "#447C7C",
   comment = "#222D38",
   path = "#3A5830",
+  macro = "#543F54",
+  escape = "#543F54",
+  regexp = "#20301A",
+  link = "#131A20",
 
   -- Diagnostic
   error = "#6A2828",

--- a/palette/akari-dawn.toml
+++ b/palette/akari-dawn.toml
@@ -127,6 +127,16 @@ success = "colors.life"
 # semantic.path — file paths (URLs use bright-blue separately)
 path = "ansi.green"
 
+# Special syntax
+# semantic.macro — metaprogramming, preprocessor
+macro = "ansi.bright.magenta"
+# semantic.escape — escape sequences (\n, \t, etc.)
+escape = "ansi.bright.magenta"
+# semantic.regexp — regular expression literals
+regexp = "ansi.bright.green"
+# semantic.link — URLs, hyperlinks
+link = "ansi.bright.blue"
+
 #
 # ANSI (terminal compatibility)
 #

--- a/palette/akari-night.toml
+++ b/palette/akari-night.toml
@@ -127,6 +127,16 @@ success = "colors.life"
 # semantic.path — file paths (URLs use bright-blue separately)
 path = "ansi.green"
 
+# Special syntax
+# semantic.macro — metaprogramming, preprocessor
+macro = "ansi.bright.magenta"
+# semantic.escape — escape sequences (\n, \t, etc.)
+escape = "ansi.bright.magenta"
+# semantic.regexp — regular expression literals
+regexp = "ansi.bright.green"
+# semantic.link — URLs, hyperlinks
+link = "ansi.bright.blue"
+
 #
 # ANSI (terminal compatibility)
 #

--- a/templates/helix/akari-{name}.toml.tera
+++ b/templates/helix/akari-{name}.toml.tera
@@ -95,7 +95,7 @@
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "bright-blue", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "link", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "cyan" }
 "markup.link.label" = { fg = "magenta" }
 "markup.quote" = { fg = "comment", modifiers = ["dim"] }
@@ -117,15 +117,15 @@
 "constant.builtin" = { fg = "constant" }
 "constant.builtin.boolean" = { fg = "constant" }
 "constant.character" = { fg = "lantern" }
-"constant.character.escape" = { fg = "bright-magenta" }
+"constant.character.escape" = { fg = "escape" }
 "constant.numeric" = { fg = "constant" }
 
 "string" = { fg = "green" }
-"string.regexp" = { fg = "bright-green" }
+"string.regexp" = { fg = "regexp" }
 "string.regexp.special" = { fg = "bright-magenta" }
 "string.special" = { fg = "green" }
 "string.special.path" = { fg = "path" }
-"string.special.url" = { fg = "bright-blue", modifiers = ["underlined"] }
+"string.special.url" = { fg = "link", modifiers = ["underlined"] }
 "string.special.symbol" = { fg = "bright-magenta" }
 
 "comment" = { fg = "comment", modifiers = ["dim"] }
@@ -154,7 +154,7 @@
 "keyword.control.return" = { fg = "lantern" }
 "keyword.control.exception" = { fg = "lantern" }
 "keyword.operator" = { fg = "lantern" }
-"keyword.directive" = { fg = "bright-magenta" }
+"keyword.directive" = { fg = "macro" }
 "keyword.function" = { fg = "lantern" }
 "keyword.storage" = { fg = "lantern" }
 "keyword.storage.type" = { fg = "lantern" }
@@ -165,7 +165,7 @@
 "function" = { fg = "magenta" }
 "function.builtin" = { fg = "bright-magenta" }
 "function.method" = { fg = "magenta" }
-"function.macro" = { fg = "bright-magenta" }
+"function.macro" = { fg = "macro" }
 "function.special" = { fg = "bright-magenta" }
 
 "tag" = { fg = "lantern" }
@@ -216,5 +216,9 @@ amber = "{{ colors.lantern.far }}"
 constant = "{{ semantic.constant }}"
 comment = "{{ semantic.comment }}"
 path = "{{ semantic.path }}"
+macro = "{{ semantic.macro }}"
+escape = "{{ semantic.escape }}"
+regexp = "{{ semantic.regexp }}"
+link = "{{ semantic.link }}"
 sunken = "{{ layers.sunken }}"
 match-bg = "{{ state.match_bg }}"

--- a/templates/nvim/lua/akari/palette.lua.tera
+++ b/templates/nvim/lua/akari/palette.lua.tera
@@ -49,6 +49,10 @@ M.night = {
   constant = "{{ night_semantic.constant }}",
   comment = "{{ night_semantic.comment }}",
   path = "{{ night_semantic.path }}",
+  macro = "{{ night_semantic.macro }}",
+  escape = "{{ night_semantic.escape }}",
+  regexp = "{{ night_semantic.regexp }}",
+  link = "{{ night_semantic.link }}",
 
   -- Diagnostic
   error = "{{ night_state.error }}",
@@ -111,6 +115,10 @@ M.dawn = {
   constant = "{{ dawn_semantic.constant }}",
   comment = "{{ dawn_semantic.comment }}",
   path = "{{ dawn_semantic.path }}",
+  macro = "{{ dawn_semantic.macro }}",
+  escape = "{{ dawn_semantic.escape }}",
+  regexp = "{{ dawn_semantic.regexp }}",
+  link = "{{ dawn_semantic.link }}",
 
   -- Diagnostic
   error = "{{ dawn_state.error }}",

--- a/templates/vscode/themes/akari-{name}-color-theme.json.tera
+++ b/templates/vscode/themes/akari-{name}-color-theme.json.tera
@@ -38,7 +38,7 @@
     "editor.findMatchHighlightBackground": "{{ colors.lantern.mid }}20",
     "editor.lineHighlightBackground": "{{ layers.sunken }}",
     "editor.lineHighlightBorder": "{{ layers.sunken }}00",
-    "editorLink.activeForeground": "{{ ansi_bright.blue }}",
+    "editorLink.activeForeground": "{{ semantic.link }}",
 
     "editorGutter.background": "{{ base.background }}",
     "editorGutter.modifiedBackground": "{{ colors.lantern.mid }}",
@@ -362,7 +362,7 @@
         "string.escape"
       ],
       "settings": {
-        "foreground": "{{ ansi_bright.magenta }}"
+        "foreground": "{{ semantic.escape }}"
       }
     },
     {
@@ -371,7 +371,7 @@
         "string.regexp"
       ],
       "settings": {
-        "foreground": "{{ ansi_bright.green }}"
+        "foreground": "{{ semantic.regexp }}"
       }
     },
     {
@@ -516,7 +516,7 @@
         "support.function.macro"
       ],
       "settings": {
-        "foreground": "{{ ansi_bright.magenta }}"
+        "foreground": "{{ semantic.macro }}"
       }
     },
     {
@@ -825,7 +825,7 @@
         "string.other.link"
       ],
       "settings": {
-        "foreground": "{{ ansi_bright.blue }}",
+        "foreground": "{{ semantic.link }}",
         "fontStyle": "underline"
       }
     },
@@ -1011,7 +1011,7 @@
         "keyword.control.at-rule.extend"
       ],
       "settings": {
-        "foreground": "{{ ansi_bright.magenta }}"
+        "foreground": "{{ semantic.macro }}"
       }
     },
     {
@@ -1085,7 +1085,7 @@
     "method": "{{ colors.muted }}",
     "function.defaultLibrary": "{{ ansi_bright.magenta }}",
     "method.defaultLibrary": "{{ ansi_bright.magenta }}",
-    "macro": "{{ ansi_bright.magenta }}",
+    "macro": "{{ semantic.macro }}",
     "variable": "{{ base.foreground }}",
     "variable.readonly": "{{ semantic.constant }}",
     "variable.defaultLibrary": {


### PR DESCRIPTION
## Summary

- Add four new semantic keys to palettes (`macro`, `escape`, `regexp`, `link`) for editor token highlighting
- Support `ansi.bright.*` references in palette expressions
- Refactor `RawAnsi` to use `#[serde(flatten)]` with `RawAnsiColors`, reducing duplication
- Update helix, nvim, and vscode templates to use the new semantic keys

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (all 51 tests)
- [x] `cargo run -- generate --tool helix` generates themes correctly