### PR TITLE
Update muted color in VSCode README

### DIFF
--- a/dist/vscode/README.md
+++ b/dist/vscode/README.md
@@ -66,7 +66,7 @@ ln -s $(pwd)/akari-vscode ~/.vscode/extensions/akari-theme
 | Amber      | `#D4A05A` |
 | Life       | `#7FAF6A` |
 | Night      | `#5A6F82` |
-| Muted      | `#7C6A8A` |
+| Muted      | `#8E7BA0` |
 
 ### Akari Dawn (Light)
 

--- a/templates/vscode/README.md
+++ b/templates/vscode/README.md
@@ -66,7 +66,7 @@ ln -s $(pwd)/akari-vscode ~/.vscode/extensions/akari-theme
 | Amber      | `#D4A05A` |
 | Life       | `#7FAF6A` |
 | Night      | `#5A6F82` |
-| Muted      | `#7C6A8A` |
+| Muted      | `#8E7BA0` |
 
 ### Akari Dawn (Light)
 


### PR DESCRIPTION
## Overview

Updates the VSCode README to reflect the new muted purple color value that was changed in #21.

## Changes

- `templates/vscode/README.md`: Updated color reference from `#7C6A8A` to `#8E7BA0`
- `dist/vscode/README.md`: Regenerated to reflect the change

## Context

The muted purple color was updated in #21 to improve readability, but the VSCode README still referenced the old value.

## Testing

- ✅ `cargo test` - All tests passed
- ✅ Generated VSCode theme successfully