### PR TITLE
Add missing helix scopes and new palette keys

### DIFF
--- a/dist/helix/akari-dawn.toml
+++ b/dist/helix/akari-dawn.toml
@@ -5,19 +5,29 @@
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.text.inactive" = { fg = "bright-black" }
+"ui.text.info" = { fg = "info" }
+"ui.text.directory" = { fg = "directory" }
 
 "ui.cursor" = { fg = "cursor-text", bg = "cursor" }
+"ui.cursor.normal" = { fg = "cursor-text", bg = "cursor" }
 "ui.cursor.primary" = { fg = "cursor-text", bg = "cursor" }
+"ui.cursor.primary.normal" = { fg = "cursor-text", bg = "cursor" }
 "ui.cursor.match" = { fg = "lantern", bg = "sunken", modifiers = ["bold"] }
 "ui.cursor.insert" = { fg = "cursor-text", bg = "green" }
+"ui.cursor.primary.insert" = { fg = "cursor-text", bg = "green" }
 "ui.cursor.select" = { fg = "cursor-text", bg = "magenta" }
+"ui.cursor.primary.select" = { fg = "cursor-text", bg = "magenta" }
 
 "ui.selection" = { bg = "selection-bg" }
 "ui.selection.primary" = { bg = "selection-bg" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
+"ui.cursorline.secondary" = { bg = "surface" }
 "ui.cursorcolumn.primary" = { bg = "surface" }
+"ui.cursorcolumn.secondary" = { bg = "surface" }
 
+"ui.gutter" = { bg = "background" }
+"ui.gutter.selected" = { bg = "cursorline" }
 "ui.linenr" = { fg = "bright-black" }
 "ui.linenr.selected" = { fg = "lantern" }
 
@@ -29,7 +39,9 @@
 "ui.statusline.separator" = { fg = "bright-black", bg = "surface" }
 
 "ui.popup" = { fg = "foreground", bg = "raised" }
+"ui.popup.info" = { fg = "foreground", bg = "raised" }
 "ui.window" = { fg = "border" }
+"ui.background.separator" = { bg = "surface" }
 "ui.help" = { fg = "foreground", bg = "raised" }
 
 "ui.menu" = { fg = "foreground", bg = "raised" }
@@ -49,11 +61,13 @@
 "ui.debug.active" = { fg = "lantern", modifiers = ["bold"] }
 
 "ui.highlight" = { bg = "match-bg" }
+"ui.highlight.frameline" = { bg = "surface" }
 
 "ui.bufferline" = { fg = "bright-black", bg = "surface" }
 "ui.bufferline.active" = { fg = "foreground", bg = "background" }
 "ui.bufferline.background" = { bg = "surface" }
 
+"ui.picker.header" = { fg = "bright-blue", modifiers = ["bold"] }
 "ui.picker.header.column" = { fg = "bright-blue", modifiers = ["bold"] }
 "ui.picker.header.column.active" = { fg = "lantern", modifiers = ["bold"] }
 
@@ -70,6 +84,8 @@
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
+"tabstop" = { underline = { color = "lantern", style = "dashed" } }
+
 # Diff
 "diff.plus" = "green"
 "diff.plus.gutter" = "green"
@@ -77,6 +93,8 @@
 "diff.minus.gutter" = "red"
 "diff.delta" = "amber"
 "diff.delta.gutter" = "amber"
+"diff.delta.moved" = "diff-moved"
+"diff.delta.conflict" = { fg = "conflict", modifiers = ["bold"] }
 
 # Markup
 "markup.heading" = { fg = "lantern", modifiers = ["bold"] }
@@ -102,6 +120,12 @@
 "markup.raw" = { fg = "bright-green" }
 "markup.raw.inline" = { fg = "bright-green" }
 "markup.raw.block" = { fg = "bright-green" }
+"markup.normal.completion" = "foreground"
+"markup.normal.hover" = "foreground"
+"markup.heading.completion" = { fg = "lantern", modifiers = ["bold"] }
+"markup.heading.hover" = { fg = "lantern", modifiers = ["bold"] }
+"markup.raw.inline.completion" = { fg = "bright-green" }
+"markup.raw.inline.hover" = { fg = "bright-green" }
 
 # Syntax highlighting
 "attribute" = { fg = "amber" }
@@ -119,6 +143,8 @@
 "constant.character" = { fg = "lantern" }
 "constant.character.escape" = { fg = "escape" }
 "constant.numeric" = { fg = "constant" }
+"constant.numeric.integer" = { fg = "constant" }
+"constant.numeric.float" = { fg = "constant" }
 
 "string" = { fg = "green" }
 "string.regexp" = { fg = "regexp" }
@@ -130,14 +156,17 @@
 
 "comment" = { fg = "comment", modifiers = ["dim"] }
 "comment.line" = { fg = "comment", modifiers = ["dim"] }
+"comment.line.documentation" = { fg = "comment", modifiers = ["dim"] }
 "comment.block" = { fg = "comment", modifiers = ["dim"] }
 "comment.block.documentation" = { fg = "comment", modifiers = ["dim"] }
+"comment.unused" = { fg = "comment", modifiers = ["dim"] }
 
 "variable" = "foreground"
 "variable.builtin" = { fg = "bright-red" }
 "variable.parameter" = "foreground"
 "variable.other" = "foreground"
 "variable.other.member" = "foreground"
+"variable.other.member.private" = "foreground"
 
 "label" = { fg = "amber" }
 
@@ -165,6 +194,7 @@
 "function" = { fg = "magenta" }
 "function.builtin" = { fg = "bright-magenta" }
 "function.method" = { fg = "magenta" }
+"function.method.private" = { fg = "magenta" }
 "function.macro" = { fg = "macro" }
 "function.special" = { fg = "bright-magenta" }
 
@@ -220,5 +250,9 @@ macro = "#543F54"
 escape = "#543F54"
 regexp = "#20301A"
 link = "#131A20"
+directory = "#305858"
 sunken = "#DDD2C9"
 match-bg = "#D2BFB5"
+info = "#304050"
+diff-moved = "#304050"
+conflict = "#6A2828"

--- a/dist/helix/akari-night.toml
+++ b/dist/helix/akari-night.toml
@@ -5,19 +5,29 @@
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.text.inactive" = { fg = "bright-black" }
+"ui.text.info" = { fg = "info" }
+"ui.text.directory" = { fg = "directory" }
 
 "ui.cursor" = { fg = "cursor-text", bg = "cursor" }
+"ui.cursor.normal" = { fg = "cursor-text", bg = "cursor" }
 "ui.cursor.primary" = { fg = "cursor-text", bg = "cursor" }
+"ui.cursor.primary.normal" = { fg = "cursor-text", bg = "cursor" }
 "ui.cursor.match" = { fg = "lantern", bg = "sunken", modifiers = ["bold"] }
 "ui.cursor.insert" = { fg = "cursor-text", bg = "green" }
+"ui.cursor.primary.insert" = { fg = "cursor-text", bg = "green" }
 "ui.cursor.select" = { fg = "cursor-text", bg = "magenta" }
+"ui.cursor.primary.select" = { fg = "cursor-text", bg = "magenta" }
 
 "ui.selection" = { bg = "selection-bg" }
 "ui.selection.primary" = { bg = "selection-bg" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
+"ui.cursorline.secondary" = { bg = "surface" }
 "ui.cursorcolumn.primary" = { bg = "surface" }
+"ui.cursorcolumn.secondary" = { bg = "surface" }
 
+"ui.gutter" = { bg = "background" }
+"ui.gutter.selected" = { bg = "cursorline" }
 "ui.linenr" = { fg = "bright-black" }
 "ui.linenr.selected" = { fg = "lantern" }
 
@@ -29,7 +39,9 @@
 "ui.statusline.separator" = { fg = "bright-black", bg = "surface" }
 
 "ui.popup" = { fg = "foreground", bg = "raised" }
+"ui.popup.info" = { fg = "foreground", bg = "raised" }
 "ui.window" = { fg = "border" }
+"ui.background.separator" = { bg = "surface" }
 "ui.help" = { fg = "foreground", bg = "raised" }
 
 "ui.menu" = { fg = "foreground", bg = "raised" }
@@ -49,11 +61,13 @@
 "ui.debug.active" = { fg = "lantern", modifiers = ["bold"] }
 
 "ui.highlight" = { bg = "match-bg" }
+"ui.highlight.frameline" = { bg = "surface" }
 
 "ui.bufferline" = { fg = "bright-black", bg = "surface" }
 "ui.bufferline.active" = { fg = "foreground", bg = "background" }
 "ui.bufferline.background" = { bg = "surface" }
 
+"ui.picker.header" = { fg = "bright-blue", modifiers = ["bold"] }
 "ui.picker.header.column" = { fg = "bright-blue", modifiers = ["bold"] }
 "ui.picker.header.column.active" = { fg = "lantern", modifiers = ["bold"] }
 
@@ -70,6 +84,8 @@
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
+"tabstop" = { underline = { color = "lantern", style = "dashed" } }
+
 # Diff
 "diff.plus" = "green"
 "diff.plus.gutter" = "green"
@@ -77,6 +93,8 @@
 "diff.minus.gutter" = "red"
 "diff.delta" = "amber"
 "diff.delta.gutter" = "amber"
+"diff.delta.moved" = "diff-moved"
+"diff.delta.conflict" = { fg = "conflict", modifiers = ["bold"] }
 
 # Markup
 "markup.heading" = { fg = "lantern", modifiers = ["bold"] }
@@ -102,6 +120,12 @@
 "markup.raw" = { fg = "bright-green" }
 "markup.raw.inline" = { fg = "bright-green" }
 "markup.raw.block" = { fg = "bright-green" }
+"markup.normal.completion" = "foreground"
+"markup.normal.hover" = "foreground"
+"markup.heading.completion" = { fg = "lantern", modifiers = ["bold"] }
+"markup.heading.hover" = { fg = "lantern", modifiers = ["bold"] }
+"markup.raw.inline.completion" = { fg = "bright-green" }
+"markup.raw.inline.hover" = { fg = "bright-green" }
 
 # Syntax highlighting
 "attribute" = { fg = "amber" }
@@ -119,6 +143,8 @@
 "constant.character" = { fg = "lantern" }
 "constant.character.escape" = { fg = "escape" }
 "constant.numeric" = { fg = "constant" }
+"constant.numeric.integer" = { fg = "constant" }
+"constant.numeric.float" = { fg = "constant" }
 
 "string" = { fg = "green" }
 "string.regexp" = { fg = "regexp" }
@@ -130,14 +156,17 @@
 
 "comment" = { fg = "comment", modifiers = ["dim"] }
 "comment.line" = { fg = "comment", modifiers = ["dim"] }
+"comment.line.documentation" = { fg = "comment", modifiers = ["dim"] }
 "comment.block" = { fg = "comment", modifiers = ["dim"] }
 "comment.block.documentation" = { fg = "comment", modifiers = ["dim"] }
+"comment.unused" = { fg = "comment", modifiers = ["dim"] }
 
 "variable" = "foreground"
 "variable.builtin" = { fg = "bright-red" }
 "variable.parameter" = "foreground"
 "variable.other" = "foreground"
 "variable.other.member" = "foreground"
+"variable.other.member.private" = "foreground"
 
 "label" = { fg = "amber" }
 
@@ -165,6 +194,7 @@
 "function" = { fg = "magenta" }
 "function.builtin" = { fg = "bright-magenta" }
 "function.method" = { fg = "magenta" }
+"function.method.private" = { fg = "magenta" }
 "function.macro" = { fg = "macro" }
 "function.special" = { fg = "bright-magenta" }
 
@@ -220,5 +250,9 @@ macro = "#B4A7C0"
 escape = "#B4A7C0"
 regexp = "#A1C492"
 link = "#8195A8"
+directory = "#6F8F8A"
 sunken = "#302121"
 match-bg = "#3A2522"
+info = "#5A6F82"
+diff-moved = "#5A6F82"
+conflict = "#D25046"

--- a/palette/akari-dawn.toml
+++ b/palette/akari-dawn.toml
@@ -7,16 +7,16 @@ description = "A light palette inspired by Japanese alleys lit by round lanterns
 # Same pigments, different light. The lantern dims as dawn arrives.
 #
 [colors.lantern]
-ember = "#7A3828"  # inner heat — cooling embers
-near = "#6A2828"   # hibukuro — paper in morning light
-mid = "#8A4530"    # glow — fading lantern
-far = "#B07840"    # warm blur — amber in morning light
+ember = "#7A3828" # inner heat — cooling embers
+near = "#6A2828"  # hibukuro — paper in morning light
+mid = "#8A4530"   # glow — fading lantern
+far = "#B07840"   # warm blur — amber in morning light
 
 [colors]
-life = "#3A5830"   # plants catching first light
-night = "#304050"  # quiet morning air
-rain = "#305858"   # rain puddles — reflections on wet stones
-muted = "#806080"  # distant, unobtrusive
+life = "#3A5830"  # plants catching first light
+night = "#304050" # quiet morning air
+rain = "#305858"  # rain puddles — reflections on wet stones
+muted = "#806080" # distant, unobtrusive
 
 #
 # Base (reading foundation)
@@ -86,6 +86,10 @@ diff_added = "darken(colors.life, 0.15)"
 diff_removed = "ansi.red"
 # state.diff_changed — amber in morning light
 diff_changed = "darken(colors.lantern.far, 0.10)"
+# state.diff_moved — moved code in diff
+diff_moved = "colors.night"
+# state.conflict — merge conflict marker
+conflict = "ansi.red"
 
 #
 # Semantic (syntax roles)
@@ -136,6 +140,8 @@ escape = "ansi.bright.magenta"
 regexp = "ansi.bright.green"
 # semantic.link — URLs, hyperlinks
 link = "ansi.bright.blue"
+# semantic.directory — directory paths in file picker
+directory = "ansi.cyan"
 
 #
 # ANSI (terminal compatibility)

--- a/palette/akari-night.toml
+++ b/palette/akari-night.toml
@@ -86,6 +86,10 @@ diff_added = "colors.life"
 diff_removed = "ansi.red"
 # state.diff_changed
 diff_changed = "colors.lantern.far"
+# state.diff_moved — moved code in diff
+diff_moved = "colors.night"
+# state.conflict — merge conflict marker
+conflict = "ansi.red"
 
 #
 # Semantic (syntax roles)
@@ -136,6 +140,8 @@ escape = "ansi.bright.magenta"
 regexp = "ansi.bright.green"
 # semantic.link — URLs, hyperlinks
 link = "ansi.bright.blue"
+# semantic.directory — directory paths in file picker
+directory = "ansi.cyan"
 
 #
 # ANSI (terminal compatibility)

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -55,6 +55,8 @@ struct RawState {
     diff_added: ColorExpr,
     diff_removed: ColorExpr,
     diff_changed: ColorExpr,
+    diff_moved: ColorExpr,
+    conflict: ColorExpr,
 }
 
 impl RawState {
@@ -73,6 +75,8 @@ impl RawState {
             diff_added: resolve_expr(resolver, &self.diff_added)?,
             diff_removed: resolve_expr(resolver, &self.diff_removed)?,
             diff_changed: resolve_expr(resolver, &self.diff_changed)?,
+            diff_moved: resolve_expr(resolver, &self.diff_moved)?,
+            conflict: resolve_expr(resolver, &self.conflict)?,
         })
     }
 }
@@ -129,6 +133,7 @@ struct RawSemantic {
     escape: ColorExpr,
     regexp: ColorExpr,
     link: ColorExpr,
+    directory: ColorExpr,
 }
 
 impl RawSemantic {
@@ -149,6 +154,7 @@ impl RawSemantic {
             escape: resolve_expr(resolver, &self.escape)?,
             regexp: resolve_expr(resolver, &self.regexp)?,
             link: resolve_expr(resolver, &self.link)?,
+            directory: resolve_expr(resolver, &self.directory)?,
         })
     }
 }
@@ -202,6 +208,8 @@ pub struct State {
     pub diff_added: String,
     pub diff_removed: String,
     pub diff_changed: String,
+    pub diff_moved: String,
+    pub conflict: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -221,6 +229,7 @@ pub struct Semantic {
     pub escape: String,
     pub regexp: String,
     pub link: String,
+    pub directory: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -797,6 +806,8 @@ active_bg = "#2A3540"
 diff_added = "#7FAF6A"
 diff_removed = "#D65A3A"
 diff_changed = "#D4A05A"
+diff_moved = "#5A6F82"
+conflict = "#D65A3A"
 
 [semantic]
 text = "base.foreground"
@@ -814,6 +825,7 @@ macro = "ansi.bright.magenta"
 escape = "ansi.bright.magenta"
 regexp = "ansi.bright.green"
 link = "ansi.bright.blue"
+directory = "ansi.cyan"
 
 [ansi]
 black = "#171B22"

--- a/templates/helix/akari-{name}.toml.tera
+++ b/templates/helix/akari-{name}.toml.tera
@@ -5,19 +5,29 @@
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection-fg", bg = "selection-bg" }
 "ui.text.inactive" = { fg = "bright-black" }
+"ui.text.info" = { fg = "info" }
+"ui.text.directory" = { fg = "directory" }
 
 "ui.cursor" = { fg = "cursor-text", bg = "cursor" }
+"ui.cursor.normal" = { fg = "cursor-text", bg = "cursor" }
 "ui.cursor.primary" = { fg = "cursor-text", bg = "cursor" }
+"ui.cursor.primary.normal" = { fg = "cursor-text", bg = "cursor" }
 "ui.cursor.match" = { fg = "lantern", bg = "sunken", modifiers = ["bold"] }
 "ui.cursor.insert" = { fg = "cursor-text", bg = "green" }
+"ui.cursor.primary.insert" = { fg = "cursor-text", bg = "green" }
 "ui.cursor.select" = { fg = "cursor-text", bg = "magenta" }
+"ui.cursor.primary.select" = { fg = "cursor-text", bg = "magenta" }
 
 "ui.selection" = { bg = "selection-bg" }
 "ui.selection.primary" = { bg = "selection-bg" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
+"ui.cursorline.secondary" = { bg = "surface" }
 "ui.cursorcolumn.primary" = { bg = "surface" }
+"ui.cursorcolumn.secondary" = { bg = "surface" }
 
+"ui.gutter" = { bg = "background" }
+"ui.gutter.selected" = { bg = "cursorline" }
 "ui.linenr" = { fg = "bright-black" }
 "ui.linenr.selected" = { fg = "lantern" }
 
@@ -29,7 +39,9 @@
 "ui.statusline.separator" = { fg = "bright-black", bg = "surface" }
 
 "ui.popup" = { fg = "foreground", bg = "raised" }
+"ui.popup.info" = { fg = "foreground", bg = "raised" }
 "ui.window" = { fg = "border" }
+"ui.background.separator" = { bg = "surface" }
 "ui.help" = { fg = "foreground", bg = "raised" }
 
 "ui.menu" = { fg = "foreground", bg = "raised" }
@@ -49,11 +61,13 @@
 "ui.debug.active" = { fg = "lantern", modifiers = ["bold"] }
 
 "ui.highlight" = { bg = "match-bg" }
+"ui.highlight.frameline" = { bg = "surface" }
 
 "ui.bufferline" = { fg = "bright-black", bg = "surface" }
 "ui.bufferline.active" = { fg = "foreground", bg = "background" }
 "ui.bufferline.background" = { bg = "surface" }
 
+"ui.picker.header" = { fg = "bright-blue", modifiers = ["bold"] }
 "ui.picker.header.column" = { fg = "bright-blue", modifiers = ["bold"] }
 "ui.picker.header.column.active" = { fg = "lantern", modifiers = ["bold"] }
 
@@ -70,6 +84,8 @@
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
+"tabstop" = { underline = { color = "lantern", style = "dashed" } }
+
 # Diff
 "diff.plus" = "green"
 "diff.plus.gutter" = "green"
@@ -77,6 +93,8 @@
 "diff.minus.gutter" = "red"
 "diff.delta" = "amber"
 "diff.delta.gutter" = "amber"
+"diff.delta.moved" = "diff-moved"
+"diff.delta.conflict" = { fg = "conflict", modifiers = ["bold"] }
 
 # Markup
 "markup.heading" = { fg = "lantern", modifiers = ["bold"] }
@@ -102,6 +120,12 @@
 "markup.raw" = { fg = "bright-green" }
 "markup.raw.inline" = { fg = "bright-green" }
 "markup.raw.block" = { fg = "bright-green" }
+"markup.normal.completion" = "foreground"
+"markup.normal.hover" = "foreground"
+"markup.heading.completion" = { fg = "lantern", modifiers = ["bold"] }
+"markup.heading.hover" = { fg = "lantern", modifiers = ["bold"] }
+"markup.raw.inline.completion" = { fg = "bright-green" }
+"markup.raw.inline.hover" = { fg = "bright-green" }
 
 # Syntax highlighting
 "attribute" = { fg = "amber" }
@@ -119,6 +143,8 @@
 "constant.character" = { fg = "lantern" }
 "constant.character.escape" = { fg = "escape" }
 "constant.numeric" = { fg = "constant" }
+"constant.numeric.integer" = { fg = "constant" }
+"constant.numeric.float" = { fg = "constant" }
 
 "string" = { fg = "green" }
 "string.regexp" = { fg = "regexp" }
@@ -130,14 +156,17 @@
 
 "comment" = { fg = "comment", modifiers = ["dim"] }
 "comment.line" = { fg = "comment", modifiers = ["dim"] }
+"comment.line.documentation" = { fg = "comment", modifiers = ["dim"] }
 "comment.block" = { fg = "comment", modifiers = ["dim"] }
 "comment.block.documentation" = { fg = "comment", modifiers = ["dim"] }
+"comment.unused" = { fg = "comment", modifiers = ["dim"] }
 
 "variable" = "foreground"
 "variable.builtin" = { fg = "bright-red" }
 "variable.parameter" = "foreground"
 "variable.other" = "foreground"
 "variable.other.member" = "foreground"
+"variable.other.member.private" = "foreground"
 
 "label" = { fg = "amber" }
 
@@ -165,6 +194,7 @@
 "function" = { fg = "magenta" }
 "function.builtin" = { fg = "bright-magenta" }
 "function.method" = { fg = "magenta" }
+"function.method.private" = { fg = "magenta" }
 "function.macro" = { fg = "macro" }
 "function.special" = { fg = "bright-magenta" }
 
@@ -220,5 +250,9 @@ macro = "{{ semantic.macro }}"
 escape = "{{ semantic.escape }}"
 regexp = "{{ semantic.regexp }}"
 link = "{{ semantic.link }}"
+directory = "{{ semantic.directory }}"
 sunken = "{{ layers.sunken }}"
 match-bg = "{{ state.match_bg }}"
+info = "{{ state.info }}"
+diff-moved = "{{ state.diff_moved }}"
+conflict = "{{ state.conflict }}"

--- a/templates/vscode/themes/akari-{name}-color-theme.json.tera
+++ b/templates/vscode/themes/akari-{name}-color-theme.json.tera
@@ -75,12 +75,12 @@
 
     "editorOverviewRuler.border": "{{ layers.border }}",
     "editorOverviewRuler.errorForeground": "{{ state.error }}",
-    "editorOverviewRuler.warningForeground": "{{ colors.lantern.mid }}",
-    "editorOverviewRuler.infoForeground": "{{ colors.night }}",
+    "editorOverviewRuler.warningForeground": "{{ state.warning }}",
+    "editorOverviewRuler.infoForeground": "{{ state.info }}",
 
     "editorError.foreground": "{{ state.error }}",
-    "editorWarning.foreground": "{{ colors.lantern.mid }}",
-    "editorInfo.foreground": "{{ colors.night }}",
+    "editorWarning.foreground": "{{ state.warning }}",
+    "editorInfo.foreground": "{{ state.info }}",
     "editorHint.foreground": "{{ semantic.comment }}",
 
     "editorWidget.background": "{{ layers.inset }}",
@@ -171,7 +171,7 @@
     "list.focusForeground": "{{ state.selection_fg }}",
     "list.highlightForeground": "{{ colors.lantern.mid }}",
     "list.errorForeground": "{{ state.error }}",
-    "list.warningForeground": "{{ colors.lantern.mid }}",
+    "list.warningForeground": "{{ state.warning }}",
 
     "quickInput.background": "{{ layers.inset }}",
     "quickInput.foreground": "{{ base.foreground }}",
@@ -192,8 +192,8 @@
     "inputOption.activeBorder": "{{ colors.lantern.mid }}",
 
     "inputValidation.infoForeground": "{{ base.foreground }}",
-    "inputValidation.infoBackground": "{{ colors.night }}40",
-    "inputValidation.infoBorder": "{{ colors.night }}",
+    "inputValidation.infoBackground": "{{ state.info }}40",
+    "inputValidation.infoBorder": "{{ state.info }}",
     "inputValidation.warningForeground": "{{ base.background }}",
     "inputValidation.warningBackground": "{{ colors.lantern.far }}",
     "inputValidation.warningBorder": "{{ colors.lantern.far }}",
@@ -235,7 +235,7 @@
     "minimap.background": "{{ base.background }}",
     "minimap.selectionHighlight": "{{ layers.border }}",
     "minimap.errorHighlight": "{{ state.error }}",
-    "minimap.warningHighlight": "{{ colors.lantern.mid }}",
+    "minimap.warningHighlight": "{{ state.warning }}",
     "minimap.findMatchHighlight": "{{ colors.lantern.mid }}",
 
     "minimapGutter.modifiedBackground": "{{ colors.lantern.mid }}",


### PR DESCRIPTION
## Summary

- Add 29 missing scopes to helix template based on [official documentation](https://docs.helix-editor.com/themes.html)
- Introduce new palette keys (`state.diff_moved`, `state.conflict`, `semantic.directory`) for semantic consistency across tools
- Update vscode template to use state references instead of hardcoded color values

## Changes

### Helix Template
- UI scopes: `ui.gutter`, cursor variants, `ui.popup.info`, `ui.picker.header`, etc.
- Syntax scopes: `comment.unused`, `constant.numeric.*`, `function.method.private`
- Diff scopes: `diff.delta.moved`, `diff.delta.conflict`
- Markup scopes: completion/hover variants, `tabstop`

### Palette
- `state.diff_moved` — moved code in diffs (uses `colors.night`)
- `state.conflict` — merge conflict markers (uses `ansi.red`)
- `semantic.directory` — directory paths in file pickers (uses `ansi.cyan`)

### VSCode Template
- Updated warning/info scopes to use `state.warning`, `state.info` references

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] `cargo fmt` check passes
- [x] Visual verification in helix editor