### PR TITLE
tmux: leave status-right unset

### DIFF
--- a/dist/tmux/akari-dawn.conf
+++ b/dist/tmux/akari-dawn.conf
@@ -32,8 +32,11 @@ set-option -g status-justify left
 set-option -g status-left-length 100
 
 # Status right
+# Leave status-right unset so the user can compose it (e.g. tmux-continuum's
+# "#{continuum_status}", battery indicators, etc.). Setting it to an empty
+# string here would clobber any #{continuum_status} marker that tmux-continuum
+# appends after the theme is sourced, silently disabling its auto-save trigger.
 set-option -g status-right-length 100
-set-option -g status-right ""
 
 # Window status
 set-option -g window-status-format "#[fg=$AKARI_COMMENT] #I:#W "

--- a/dist/tmux/akari-night.conf
+++ b/dist/tmux/akari-night.conf
@@ -32,8 +32,11 @@ set-option -g status-justify left
 set-option -g status-left-length 100
 
 # Status right
+# Leave status-right unset so the user can compose it (e.g. tmux-continuum's
+# "#{continuum_status}", battery indicators, etc.). Setting it to an empty
+# string here would clobber any #{continuum_status} marker that tmux-continuum
+# appends after the theme is sourced, silently disabling its auto-save trigger.
 set-option -g status-right-length 100
-set-option -g status-right ""
 
 # Window status
 set-option -g window-status-format "#[fg=$AKARI_COMMENT] #I:#W "

--- a/templates/tmux/akari-{name}.conf.tera
+++ b/templates/tmux/akari-{name}.conf.tera
@@ -32,8 +32,11 @@ set-option -g status-justify left
 set-option -g status-left-length 100
 
 # Status right
+# Leave status-right unset so the user can compose it (e.g. tmux-continuum's
+# "#{continuum_status}", battery indicators, etc.). Setting it to an empty
+# string here would clobber any #{continuum_status} marker that tmux-continuum
+# appends after the theme is sourced, silently disabling its auto-save trigger.
 set-option -g status-right-length 100
-set-option -g status-right ""
 
 # Window status
 set-option -g window-status-format "#[fg=$AKARI_COMMENT] #I:#W "


### PR DESCRIPTION
## Summary

- Stop emitting `set-option -g status-right ""` from the tmux theme template.
- Regenerate `dist/tmux/akari-{night,dawn}.conf`.

## Why

The theme used to hard-clear `status-right`, which silently broke
integrations that compose into it. tmux-continuum, for example, appends
`#{continuum_status}` to `status-right` after the theme is sourced so
that the next `status-interval` tick will run its auto-save script.
Because our theme re-applied `status-right ""` after that, the
`#{continuum_status}` marker disappeared and the 10-minute auto-save
never fired — sessions that should have been resumable were lost after
reboots/power loss.

Dropping the explicit empty assignment lets the user (or plugins loaded
later) own `status-right`. Users who want it blank can still add
`set -g status-right ""` in their own config.

## Verification

```sh
cargo run --features generator -- generate --tool tmux
cargo clippy --features generator -- -D warnings
cargo fmt -- --check
cargo test --features generator
```

All green locally. `dist/tmux/akari-*.conf` regenerated and committed.

## Test plan

- [ ] CI green (clippy / fmt / test / `generate --tool all` diff check)
- [ ] Manually verify on a host where tmux-continuum is enabled: after
  sourcing the new theme, `tmux show -g status-right` returns
  `#{continuum_status}` (or whatever the user composed), and
  `~/.local/share/tmux/resurrect/` starts receiving snapshots again.
